### PR TITLE
No need to reveal too many implementation details.

### DIFF
--- a/src/drivers/adabase-driver.ads
+++ b/src/drivers/adabase-driver.ads
@@ -14,15 +14,16 @@
 --  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 --
 
+private
 with Ada.Finalization;
 
 package AdaBase.Driver is
 
-   package FIN renames Ada.Finalization;
-
    type Base_Pure is abstract tagged private;
 
 private
+   package FIN renames Ada.Finalization;
+
    type Base_Pure is abstract new FIN.Controlled with
       record
          null;


### PR DESCRIPTION
Using Ada 2005 `private with` to limit the visibility of `Ada.Finalization` to the private part of the specification.
